### PR TITLE
Feature/dev ed 30.add members endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepgram/sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Keys } from "./keys";
 import { Projects } from "./projects";
 import { Transcriber } from "./transcription";
 import { Usage } from "./usage";
+import { Members } from "./members";
 
 export class Deepgram {
   private _apiUrl: string;
@@ -12,6 +13,7 @@ export class Deepgram {
   projects: Projects;
   transcription: Transcriber;
   usage: Usage;
+  members: Members;
 
   constructor(apiKey: string, apiUrl?: string) {
     this._apiKey = apiKey;
@@ -23,6 +25,7 @@ export class Deepgram {
     this.projects = new Projects(this._apiKey, this._apiUrl);
     this.transcription = new Transcriber(this._apiKey, this._apiUrl);
     this.usage = new Usage(this._apiKey, this._apiUrl);
+    this.members = new Members(this._apiKey, this._apiUrl);
   }
 
   /**

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,4 +1,3 @@
-// import querystring from "querystring";
 import { _request } from "./httpRequest";
 import { MemberList, Message } from "./types";
 
@@ -12,7 +11,6 @@ export class Members {
    * @param projectId Unique identifier of the project
    */
   async listMembers(projectId: string): Promise<MemberList> {
-    console.log("LIST MEMBERS", projectId);
     return _request<MemberList>(
       "GET",
       this._credentials,
@@ -27,7 +25,6 @@ export class Members {
    * @param memberId Unique identifier of the project
    */
   async removeMember(projectId: string, memberId: string): Promise<Message> {
-    console.log("REMOVE MEMBER", projectId, memberId);
     return _request<Message>(
       "DELETE",
       this._credentials,

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,6 +1,6 @@
 // import querystring from "querystring";
 import { _request } from "./httpRequest";
-import { MemberList } from "./types";
+import { MemberList, Message } from "./types";
 
 export class Members {
   constructor(private _credentials: string, private _apiUrl: string) {}
@@ -18,6 +18,21 @@ export class Members {
       this._credentials,
       this._apiUrl,
       `${this.apiPath}/${projectId}/members`
+    );
+  }
+
+  /**
+   * Retrieves account objects for all of the accounts in the specified project.
+   * @param projectId Unique identifier of the project
+   * @param memberId Unique identifier of the project
+   */
+  async removeMember(projectId: string, memberId: string): Promise<Message> {
+    console.log("REMOVE MEMBER", projectId, memberId);
+    return _request<Message>(
+      "DELETE",
+      this._credentials,
+      this._apiUrl,
+      `${this.apiPath}/${projectId}/members/${memberId}`
     );
   }
 }

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,0 +1,23 @@
+// import querystring from "querystring";
+import { _request } from "./httpRequest";
+import { MemberList } from "./types";
+
+export class Members {
+  constructor(private _credentials: string, private _apiUrl: string) {}
+
+  private apiPath = "/v1/projects";
+
+  /**
+   * Retrieves account objects for all of the accounts in the specified project.
+   * @param projectId Unique identifier of the project
+   */
+  async listMembers(projectId: string): Promise<MemberList> {
+    console.log("LIST MEMBERS", projectId);
+    return _request<MemberList>(
+      "GET",
+      this._credentials,
+      this._apiUrl,
+      `${this.apiPath}/${projectId}/members`
+    );
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from "./keyResponse";
 export * from "./liveTranscriptionOptions";
 export * from "./liveTranscriptionResponse";
 export * from "./member";
+export * from "./memberList";
 export * from "./metadata";
 export * from "./prerecordedTranscriptionOptions";
 export * from "./prerecordedTranscriptionResponse";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,3 +27,4 @@ export * from "./usageResponse";
 export * from "./usageResponseDetail";
 export * from "./utterance";
 export * from "./wordBase";
+export * from "./message";

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,6 +1,7 @@
 export type Member = {
   member_id: string;
-  name?: string;
+  first_name?: string;
+  last_name?: string;
   scopes?: Array<string>;
   email: string;
 };

--- a/src/types/memberList.ts
+++ b/src/types/memberList.ts
@@ -1,0 +1,5 @@
+import { Member } from "./member";
+
+export type MemberList = {
+  members?: Array<Member>;
+};

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,3 @@
+export type Message = {
+  message?: string;
+};


### PR DESCRIPTION
closes #30 

I added the members endpoint to the SDK. 

I used similar method names as the `usage` endpoint was using. Let me know if I should change it to be just the verb (eg. `list` instead of `listMembers`)

I also updated the Members type object to having `first_name` and `last_name` instead of just `name` because that is what is coming back from the API. 

I added a generic Message type also for the responses that come back from DELETE calls. I noticed on the `keys` endpoint we are saying it returns a `void` but we actually return an object with a `message` property. I thought we might want to update that.

Do I need to write any tests surrounding this?
