### PR TITLE
Fixing version parameter of transcription options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.2.3]
+
 ### Fixed
 
 - Getting the list of API keys was returning the wrong type of object. The SDK now returns the correct object type, but also returns what was previously implemented with deprecation notices.
-
----
+- The `version` parameter was typed as required for both pre-recorded and live transcription. Changed this to be optional.
 
 ## [1.2.2]
 
@@ -155,7 +158,8 @@ throw an error.
 
 ---
 
-[unreleased]: https://github.com/deepgram/node-sdk/compare/1.2.2...HEAD
+[unreleased]: https://github.com/deepgram/node-sdk/compare/1.2.3...HEAD
+[1.2.2]: https://github.com/deepgram/node-sdk/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/deepgram/node-sdk/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/deepgram/node-sdk/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/deepgram/node-sdk/compare/1.1.0...1.2.0

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -18,7 +18,7 @@ export type LiveTranscriptionOptions = {
    * @remarks latest OR <version_id>
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/version
    */
-  version: string;
+  version?: string;
   /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -18,7 +18,7 @@ export type PrerecordedTranscriptionOptions = {
    * @remarks latest OR <version_id>
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/version
    */
-  version: string;
+  version?: string;
   /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US


### PR DESCRIPTION
The `version` parameter was typed as required for both pre-recorded and live transcription. Changed this to be optional.