### PR TITLE
Change ReadStreamSource to accept stream.Readable instead of only fs.ReadStream.

### DIFF
--- a/src/httpRequest.ts
+++ b/src/httpRequest.ts
@@ -1,4 +1,4 @@
-import { ReadStream } from "fs";
+import { Readable } from "stream";
 import { request, RequestOptions } from "https";
 import { userAgent } from "./userAgent";
 
@@ -7,12 +7,12 @@ const _requestOptions = (
   apiUrl: string,
   path: string,
   method: string,
-  payload?: string | Buffer | ReadStream,
+  payload?: string | Buffer | Readable,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override_options?: any
 ): RequestOptions => {
   const additionalHeaders: { [name: string]: string | number } = {};
-  if (payload && !(payload instanceof ReadStream)) {
+  if (payload && !(payload instanceof Readable)) {
     additionalHeaders["Content-Length"] = Buffer.byteLength(payload);
   }
 
@@ -40,7 +40,7 @@ export function _request<T>(
   api_key: string,
   apiUrl: string,
   path: string,
-  payload?: string | Buffer | ReadStream,
+  payload?: string | Buffer | Readable,
   // eslint-disable-next-line @typescript-eslint/ban-types
   options?: Object
 ): Promise<T> {
@@ -85,7 +85,7 @@ export function _request<T>(
       });
 
       if (payload) {
-        if (payload instanceof ReadStream) {
+        if (payload instanceof Readable) {
           payload.pipe(httpRequest);
           payload.on("finish", function () {
             httpRequest.end();

--- a/src/transcription/preRecordedTranscription.ts
+++ b/src/transcription/preRecordedTranscription.ts
@@ -49,7 +49,7 @@ export const preRecordedTranscription = async (
     (source.mimetype === undefined || source.mimetype.length === 0)
   ) {
     throw new Error(
-      "DG: Mimetype must be provided if the source is a Buffer or a ReadStream"
+      "DG: Mimetype must be provided if the source is a Buffer or a Readable"
     );
   }
 

--- a/src/types/transcriptionSource.ts
+++ b/src/types/transcriptionSource.ts
@@ -1,9 +1,9 @@
-import { ReadStream } from "fs";
+import { Readable } from "stream";
 
 export type TranscriptionSource = UrlSource | BufferSource | ReadStreamSource;
 
 export type ReadStreamSource = {
-  stream: ReadStream;
+  stream: Readable;
   mimetype: string;
 };
 

--- a/tests/transcription/preRecordedTranscription.test.ts
+++ b/tests/transcription/preRecordedTranscription.test.ts
@@ -13,7 +13,7 @@ describe("Transcription: Pre-recorded tests", () => {
     }).catch((e) => {
       try {
         e.message.should.eq(
-          "DG: Mimetype must be provided if the source is a Buffer or a ReadStream"
+          "DG: Mimetype must be provided if the source is a Buffer or a Readable"
         );
         done();
       } catch (assertionError) {
@@ -30,7 +30,7 @@ describe("Transcription: Pre-recorded tests", () => {
     }).catch((e) => {
       try {
         e.message.should.eq(
-          "DG: Mimetype must be provided if the source is a Buffer or a ReadStream"
+          "DG: Mimetype must be provided if the source is a Buffer or a Readable"
         );
         done();
       } catch (assertionError) {


### PR DESCRIPTION
So I know when I opened the original issue I requested that ReadStream be added as a TranscriptionSource, but on usage, I realize that it's useful to use the stream.Readable for more flexibility.

Since the code doesn't actually rely on added methods, and Readable being a superclass should mean any type checks continue to work, this can be implemented as a non-breaking change.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201885737791795/1202445230557606) by [Unito](https://www.unito.io)
