### PR TITLE
Added tier to the type definitions of accepted options for live and prerecorded transcriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.3]
+
+### Added
+
+- Added `tier` to transcription option types
+
+## [1.4.2]
+
+### Added
+
+- Updated build step to build separate files for browser version
+
+## [1.4.1]
+
+### Added
+
+- Small fix for npm deployment
+
 ## [1.4.0]
 
 ### Added
 
 - Added Browser compatible versions of the live and preRecorded transcription methods
+
 ## [1.3.1]
 
 ### Updated

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -22,7 +22,7 @@ export type LiveTranscriptionOptions = {
 
   /**
    * Tier of the model to use.
-   * @default because
+   * @default base
    * @remarks Possible values are base or enhanced
    * @see https://developers.deepgram.com/documentation/features/tier/
    */

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -19,6 +19,14 @@ export type LiveTranscriptionOptions = {
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/version
    */
   version?: string;
+
+  /**
+   * Tier of the model to use.
+   * @default because
+   * @remarks Possible values are base or enhanced
+   * @see https://developers.deepgram.com/documentation/features/tier/
+   */
+  tier?: string;
   /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -20,6 +20,13 @@ export type PrerecordedTranscriptionOptions = {
    */
   version?: string;
   /**
+   * Tier of the model to use.
+   * @default because
+   * @remarks Possible values are base or enhanced
+   * @see https://developers.deepgram.com/documentation/features/tier/
+   */
+  tier?: string;
+  /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US
    * @remarks Possible values are en-GB, en-IN, en-NZ, en-US, es, fr, ko, pt,

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -21,7 +21,7 @@ export type PrerecordedTranscriptionOptions = {
   version?: string;
   /**
    * Tier of the model to use.
-   * @default because
+   * @default base
    * @remarks Possible values are base or enhanced
    * @see https://developers.deepgram.com/documentation/features/tier/
    */


### PR DESCRIPTION
Added tier to the type definitions of accepted options for live and prerecorded transcriptions



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201885737791795/1202569827943128) by [Unito](https://www.unito.io)
