### PR TITLE
Fix redaction types

### DIFF
--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -61,7 +61,7 @@ export type LiveTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: Array<string>;
+  redact?: string | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -64,7 +64,7 @@ export type PrerecordedTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: Array<string>;
+  redact?: string | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word


### PR DESCRIPTION
Here's the public API docs for our Redaction feature:

`pci`: Redacts sensitive credit card information, including credit card number, expiration date, and CVV
`numbers (or true)`: Aggressively redacts strings of numerals
`ssn`: Redacts social security numbers

It doesn't accept an array of parameters so I defined it as string or boolean to support `true`.

We could also do `redact?: 'pci' | 'numbers' | 'ssn' | true;` but that may be more of a breaking change.