### PR TITLE
Fix redaction types

### DIFF
--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -61,7 +61,7 @@ export type LiveTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: string | boolean;
+  redact?: (string|boolean)[] | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -61,7 +61,7 @@ export type LiveTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: string[] | boolean[] | boolean;
+  redact?: Array<string> | Array<boolean> | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -61,7 +61,7 @@ export type LiveTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: (string|boolean)[] | boolean;
+  redact?: string[] | boolean[] | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -64,7 +64,7 @@ export type PrerecordedTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: string | boolean;
+  redact?: (string|boolean)[] | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -64,7 +64,7 @@ export type PrerecordedTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: (string|boolean)[] | boolean;
+  redact?: string[] | boolean[] | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -64,7 +64,7 @@ export type PrerecordedTranscriptionOptions = {
    *  `ssn` (*beta*): Redacts social security numbers
    * @see https://developers.deepgram.com/api-reference/speech-recognition-api#operation/transcribeAudio/properties/redact
    */
-  redact?: string[] | boolean[] | boolean;
+  redact?: Array<string> | Array<boolean> | boolean;
 
   /**
    * Indicates whether to recognize speaker changes. When passed in, each word


### PR DESCRIPTION
Our [redaction](https://developers.deepgram.com/documentation/features/redact/) feature accepts true, false, or the options `ssn | pci | numbers `. 

Also, you can specify multiple options: `redact=ssn&redact=true` or `redact=ssn&redact=pci`.  My previous PR didn't handle these cases.