### PR TITLE
Fix built bundle not including nested browser types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ./src --ext .ts && prettier --config .prettierrc src/*.ts src/**/*.ts --write",
     "test": "mocha -r ts-node/register tests/*test.ts tests/**/*test.ts --insect",
     "watch": "nodemon -e ts --watch src --exec \"npm run build\"",
-    "types": "copyfiles -f bundle/*.d.ts dist && copyfiles -u 1 bundle/**/*.d.ts dist"
+    "types": "copyfiles -f \"bundle/*.d.ts\" dist && copyfiles -u 1 \"bundle/**/*.d.ts\" dist"
   },
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
The built bundle of this package is missing the `dist/browser/transcription` folder, which means that `dist/browser/index.d.ts` cannot get the right typing information for `Deepgram.transcription` so that gets typed as `any`. This can be seen by going to https://unpkg.com/browse/@deepgram/sdk@1.17.0/dist/browser/ and noticing the missing folder.

The root cause as far as I can tell seems to be how `copyfiles` handles glob expansion where if an argument is unquoted, then it allows the calling shell to handle it which can have unexpected results, especially when going through npm. The general suggestion I've seen previously has been to always quote arguments that have globs for these sorts of tools as they usually then fallback to something like [node-glob](https://github.com/isaacs/node-glob) which works consistently across all platforms.

With my change, I'm seeing `dist/browser/transcription` folder and the 2 expected TS files be included.