### PR TITLE
Update type of alternatives response

### DIFF
--- a/src/types/alternatives.ts
+++ b/src/types/alternatives.ts
@@ -25,7 +25,7 @@ export type Alternative = {
   /**
    * Array of paragraph objects.
    */
-  paragraphs?: Array<ParagraphGroup>;
+  paragraphs?: ParagraphGroup;
   /**
    * Array of entity objects.
    */


### PR DESCRIPTION
I tested this out with the python and NodeJS SDK, but looks like you've changed your response schema. Or does it depend on certain parameters?

https://github.com/deepgram/deepgram-node-sdk/blob/ffed5bf9bd1800554a923aa6474dcb53b7acfcb9/src/types/alternatives.ts#L28