### PR TITLE
Support arbitrary properties in request

### DIFF
--- a/src/transcription/liveTranscription.ts
+++ b/src/transcription/liveTranscription.ts
@@ -16,11 +16,14 @@ export class LiveTranscription extends EventEmitter {
     endpoint = "v1/listen"
   ) {
     super(undefined);
+    const transcriptionOptions = { ...{}, ...options };
 
     const protocol = requireSSL ? "wss" : "ws";
 
     this._socket = new WebSocket(
-      `${protocol}://${apiUrl}/${endpoint}?${querystring.stringify(options)}`,
+      `${protocol}://${apiUrl}/${endpoint}?${querystring.stringify(
+        transcriptionOptions
+      )}`,
       {
         headers: {
           Authorization: `token ${credentials}`,

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -249,4 +249,17 @@ export type LiveTranscriptionOptions = {
   tag?: Array<string>;
 
   ner?: boolean;
+
+  /**
+   * allow arbitrary unknown key/value pairs to be passed through the SDK to the API
+   */
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | readonly string[]
+    | readonly number[]
+    | readonly boolean[]
+    | null
+    | undefined;
 };

--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -253,13 +253,5 @@ export type LiveTranscriptionOptions = {
   /**
    * allow arbitrary unknown key/value pairs to be passed through the SDK to the API
    */
-  [key: string]:
-    | string
-    | number
-    | boolean
-    | readonly string[]
-    | readonly number[]
-    | readonly boolean[]
-    | null
-    | undefined;
+  [key: string]: unknown;
 };

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -148,8 +148,8 @@ export type PrerecordedTranscriptionOptions = {
   keywords?: Array<string>;
 
   /**
-   * Support for out-of-vocabulary (OOV) keyword boosting when processing streaming audio is 
-   * currently in beta; to fall back to previous keyword behavior append the query parameter 
+   * Support for out-of-vocabulary (OOV) keyword boosting when processing streaming audio is
+   * currently in beta; to fall back to previous keyword behavior append the query parameter
    * keyword_boost=legacy to your API request.
    */
   keyword_boost?: string;
@@ -279,4 +279,9 @@ export type PrerecordedTranscriptionOptions = {
   tag?: Array<string>;
 
   ner?: boolean;
+
+  /**
+   * allow arbitrary unknown key/value pairs to be passed through the SDK to the API
+   */
+  [key: string]: unknown;
 };

--- a/tests/transcription/preRecorded.test.ts
+++ b/tests/transcription/preRecorded.test.ts
@@ -140,7 +140,7 @@ describe("Pre-recorded transcription tests", () => {
       });
   });
 
-  it("Transcribe URL source with abitrary options", () => {
+  it("Transcribe URL source with arbitrary options", () => {
     const mockOptions = { ...{ blah: "test" }, ...mockPrerecordedOptions };
 
     nock(`https://${mockApiDomain}`)

--- a/tests/transcription/preRecorded.test.ts
+++ b/tests/transcription/preRecorded.test.ts
@@ -139,4 +139,18 @@ describe("Pre-recorded transcription tests", () => {
         response.should.deep.eq(mockPrerecordedResponse);
       });
   });
+
+  it("Transcribe URL source with abitrary options", () => {
+    const mockOptions = { ...{ blah: "test" }, ...mockPrerecordedOptions };
+
+    nock(`https://${mockApiDomain}`)
+      .post(`/v1/listen?${querystring.stringify(mockOptions)}`)
+      .reply(200, mockPrerecordedResponse);
+
+    deepgram.transcription
+      .preRecorded(mockUrlSource, mockOptions)
+      .then((response) => {
+        response.should.deep.eq(mockPrerecordedResponse);
+      });
+  });
 });


### PR DESCRIPTION
CFE identified a need to allow certain (will remain nameless) properties to be passed through to the API while avoiding baking in those properties to our type definitions. 