### PR TITLE
fix: uniform method format, backwards compatible

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -5,7 +5,7 @@ import {
   ProjectPatchRequest,
   RequestFunction,
   ErrorResponse,
-  Message
+  Message,
 } from "./types";
 
 export class Projects {
@@ -64,17 +64,23 @@ export class Projects {
    * @returns {Promise<ProjectPatchResponse | ErrorResponse>}
    */
   async update(
-    project: Project,
-
+    project: string | Project,
     payload: ProjectPatchRequest,
     endpoint = "v1/projects"
   ): Promise<ProjectPatchResponse | ErrorResponse> {
+    const projectObj = project as Project;
+    let projectId = project as string;
+
+    if (projectObj.project_id) {
+      projectId = projectObj.project_id;
+    }
+
     return this._request(
       "PATCH",
       this._credentials,
       this._apiUrl,
       this._requireSSL,
-      `/${endpoint}/${project.project_id}`,
+      `/${endpoint}/${projectId}`,
       JSON.stringify(payload)
     );
   }

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -57,7 +57,7 @@ export class Projects {
 
   /**
    * Update a project.
-   * @param {Project} project Project to update
+   * @param {string | Project} project Project to update
    * @param {ProjectPatchRequest} payload Details to change as an object
    * @param {string} endpoint Custom API endpoint
    *

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -5,7 +5,6 @@ import {
   ProjectPatchRequest,
   RequestFunction,
   ErrorResponse,
-  Message,
 } from "./types";
 
 export class Projects {

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -58,7 +58,7 @@ describe("Projects tests", () => {
     });
   });
 
-  it("Update project resolves", () => {
+  it("Update project w/ object resolves", () => {
     nock(`https://${mockApiDomain}`)
       .patch(`/v1/projects/${mockUuid}`)
       .reply(200, mockMessageResponse);
@@ -68,6 +68,16 @@ describe("Projects tests", () => {
       .then((response) => {
         response.should.deep.eq(mockMessageResponse);
       });
+  });
+
+  it("Update project w/ ID resolves", () => {
+    nock(`https://${mockApiDomain}`)
+      .patch(`/v1/projects/${mockUuid}`)
+      .reply(200, mockMessageResponse);
+
+    deepgram.projects.update(mockUuid, mockProjectUpdate).then((response) => {
+      response.should.deep.eq(mockMessageResponse);
+    });
   });
 
   it("Delete project resolves", () => {

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -12,7 +12,7 @@ import nock from "nock";
 
 chai.should();
 
-describe("Projects tests", () => {
+describe("Scopes tests", () => {
   let deepgram: Deepgram = new Deepgram(mockApiKey, mockApiDomain);
 
   before(() => {

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -18,7 +18,7 @@ import nock from "nock";
 
 chai.should();
 
-describe("Projects tests", () => {
+describe("Usage tests", () => {
   let deepgram: Deepgram = new Deepgram(mockApiKey, mockApiDomain);
 
   before(() => {


### PR DESCRIPTION
All but one method for projects accepts the project_id, but the project.update method accepts the whole project object, plus another object with changes.

In the API, we only send over the changes object with the project_id.

I am modifying this method to accept project_id, uniformly with our other project methods, but retaining the backwards compatibility in the developer surface.