### PR TITLE
Use nullish coalescing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { _request } from "./httpRequest";
 export class Deepgram {
   private _apiUrl: string;
   private _apiKey: string;
+  private _port: number;
   private _requireSSL: boolean;
 
   keys: Keys;
@@ -25,10 +26,11 @@ export class Deepgram {
   billing: Billing;
   scopes: Scopes;
 
-  constructor(apiKey: string, apiUrl?: string, requireSSL?: boolean) {
+  constructor(apiKey: string, apiUrl?: string, port?: number, requireSSL?: boolean) {
     this._apiKey = apiKey;
-    this._apiUrl = apiUrl || DefaultOptions.apiUrl;
-    this._requireSSL = requireSSL || DefaultOptions.requireSSL;
+    this._apiUrl = apiUrl ?? DefaultOptions.apiUrl;
+    this._requireSSL = requireSSL ?? DefaultOptions.requireSSL;
+    this._port = port;
 
     /**
      * Ensures that the provided options were provided

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import { _request } from "./httpRequest";
 export class Deepgram {
   private _apiUrl: string;
   private _apiKey: string;
-  private _port: number;
   private _requireSSL: boolean;
 
   keys: Keys;
@@ -26,11 +25,10 @@ export class Deepgram {
   billing: Billing;
   scopes: Scopes;
 
-  constructor(apiKey: string, apiUrl?: string, port?: number, requireSSL?: boolean) {
+  constructor(apiKey: string, apiUrl?: string, requireSSL?: boolean) {
     this._apiKey = apiKey;
     this._apiUrl = apiUrl ?? DefaultOptions.apiUrl;
     this._requireSSL = requireSSL ?? DefaultOptions.requireSSL;
-    this._port = port;
 
     /**
      * Ensures that the provided options were provided


### PR DESCRIPTION
Updates to the Deepgram constructor to use `??` instead of `||`.  This change makes the SDK compatible with onprem for streaming (batch needs additional updates).  The `apiUrl` could probably be left as `||`, but `requireSSL` needs to be the "nullish coalescing" operator `??` as otherwise if set to "False" for the onprem case the `||` operator will still default to the default option.