### PR TITLE
fix: find-and-replace can accept multiple strings

### DIFF
--- a/src/types/liveTranscriptionOptions.ts
+++ b/src/types/liveTranscriptionOptions.ts
@@ -29,13 +29,6 @@ export type LiveTranscriptionOptions = {
   tier?: string;
 
   /**
-   * Terms or phrases to search for in the submitted audio and replace
-   * @remarks Can send multiple instances in query string replace=this:that&replace=thisalso:thatalso. Replacing a term or phrase with nothing will remove the term or phrase from the audio transcript.
-   * @see https://developers.deepgram.com/documentation/features/replace/
-   */
-  replace?: string;
-
-  /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US
    * @remarks Possible values are en-GB, en-IN, en-NZ, en-US, es, fr, ko, pt,
@@ -115,13 +108,6 @@ export type LiveTranscriptionOptions = {
   numbers_spaces?: boolean;
 
   /**
-   * Terms or phrases to search for in the submitted audio. Deepgram searches
-   * for acoustic patterns in audio rather than text patterns in transcripts
-   * because we have noticed that acoustic pattern matching is more performant.
-   * @see https://developers.deepgram.com/documentation/features/search/
-   */
-  search?: Array<string>;
-  /**
    * Callback URL to provide if you would like your submitted audio to be
    * processed asynchronously. When passed, Deepgram will immediately respond
    * with a request_id. When it has finished analyzing the audio, it will send
@@ -131,6 +117,22 @@ export type LiveTranscriptionOptions = {
    * @see https://developers.deepgram.com/documentation/features/callback/
    */
   callback?: string;
+
+  /**
+   * Terms or phrases to search for in the submitted audio and replace
+   * @remarks Can send multiple instances in query string replace=this:that&replace=thisalso:thatalso. Replacing a term or phrase with nothing will remove the term or phrase from the audio transcript.
+   * @see https://developers.deepgram.com/documentation/features/replace/
+   */
+  replace?: string[] | string;
+
+  /**
+   * Terms or phrases to search for in the submitted audio. Deepgram searches
+   * for acoustic patterns in audio rather than text patterns in transcripts
+   * because we have noticed that acoustic pattern matching is more performant.
+   * @see https://developers.deepgram.com/documentation/features/search/
+   */
+  search?: string[] | string;
+
   /**
    * Keywords to which the model should pay particular attention to boosting
    * or suppressing to help it understand context. Just like a human listener,
@@ -138,7 +140,7 @@ export type LiveTranscriptionOptions = {
    * hard-to-decipher speech when it knows the context of the conversation.
    * @see https://developers.deepgram.com/documentation/features/keywords/
    */
-  keywords?: Array<string>;
+  keywords?: string[] | string;
 
   /**
    * Support for out-of-vocabulary (OOV) keyword boosting when processing streaming audio is

--- a/src/types/prerecordedTranscriptionOptions.ts
+++ b/src/types/prerecordedTranscriptionOptions.ts
@@ -29,13 +29,6 @@ export type PrerecordedTranscriptionOptions = {
   tier?: string;
 
   /**
-   * Terms or phrases to search for in the submitted audio and replace
-   * @remarks Can send multiple instances in query string replace=this:that&replace=thisalso:thatalso. Replacing a term or phrase with nothing will remove the term or phrase from the audio transcript.
-   * @see https://developers.deepgram.com/documentation/features/replace/
-   */
-  replace?: string;
-
-  /**
    * BCP-47 language tag that hints at the primary spoken language.
    * @default en-US
    * @remarks Possible values are en-GB, en-IN, en-NZ, en-US, es, fr, ko, pt,
@@ -120,14 +113,6 @@ export type PrerecordedTranscriptionOptions = {
   numbers_spaces?: boolean;
 
   /**
-   * Terms or phrases to search for in the submitted audio. Deepgram searches
-   * for acoustic patterns in audio rather than text patterns in transcripts
-   * because we have noticed that acoustic pattern matching is more performant.
-   * @see https://developers.deepgram.com/documentation/features/search/
-   */
-  search?: Array<string>;
-
-  /**
    * Callback URL to provide if you would like your submitted audio to be
    * processed asynchronously. When passed, Deepgram will immediately respond
    * with a request_id. When it has finished analyzing the audio, it will send
@@ -139,13 +124,28 @@ export type PrerecordedTranscriptionOptions = {
   callback?: string;
 
   /**
+   * Terms or phrases to search for in the submitted audio and replace
+   * @remarks Can send multiple instances in query string replace=this:that&replace=thisalso:thatalso. Replacing a term or phrase with nothing will remove the term or phrase from the audio transcript.
+   * @see https://developers.deepgram.com/documentation/features/replace/
+   */
+  replace?: string[] | string;
+
+  /**
+   * Terms or phrases to search for in the submitted audio. Deepgram searches
+   * for acoustic patterns in audio rather than text patterns in transcripts
+   * because we have noticed that acoustic pattern matching is more performant.
+   * @see https://developers.deepgram.com/documentation/features/search/
+   */
+  search?: string[] | string;
+
+  /**
    * Keywords to which the model should pay particular attention to boosting
    * or suppressing to help it understand context. Just like a human listener,
    * Deepgram can better understand mumbled, distorted, or otherwise
    * hard-to-decipher speech when it knows the context of the conversation.
    * @see https://developers.deepgram.com/documentation/features/keywords/
    */
-  keywords?: Array<string>;
+  keywords?: string[] | string;
 
   /**
    * Support for out-of-vocabulary (OOV) keyword boosting when processing streaming audio is


### PR DESCRIPTION
The SDK currently accepts a string, but this should allow multiple strings. `querystring.stringify` handles the rest, which is possibly why this has only come up as someone has tried to do it in TypeScript and find it doesn't like it.

fixes #145 