### PR TITLE
feat: add warning metadata and summarisation result to response type

### DIFF
--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -14,6 +14,6 @@ export type Metadata = {
       arch: string;
     };
   };
-  warnings: Array<Warning>;
+  warnings?: Array<Warning>;
   models: Array<string>;
 };

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -1,3 +1,5 @@
+import { Warning } from "./warning";
+
 export type Metadata = {
   request_id: string;
   transaction_key: string;
@@ -12,5 +14,6 @@ export type Metadata = {
       arch: string;
     };
   };
+  warnings: Array<Warning>;
   models: Array<string>;
 };

--- a/src/types/prerecordedTranscriptionResponse.ts
+++ b/src/types/prerecordedTranscriptionResponse.ts
@@ -13,6 +13,7 @@ export class PrerecordedTranscriptionResponse {
     channels: Array<Channel>;
     utterances?: Array<Utterance>;
     summary?: {
+      result: "success" | "failure";
       short: string;
     };
   };

--- a/src/types/warning.ts
+++ b/src/types/warning.ts
@@ -1,0 +1,9 @@
+export type Warning = {
+  parameter: string;
+  type:
+    | "unsupported_language"
+    | "unsupported_model"
+    | "unsupported_encoding"
+    | "deprecated";
+  message: string;
+};


### PR DESCRIPTION
Add typing for new response format supporting summarisation results and warning metadata.
e.g. output

```json
{
  "metadata": {
    ...
    "warnings": [
      {
        "parameter": "summarize",
        "type": "unsupported_language",
        "message": "Summarization isn’t supported for <detected language>."
      }
    ]
  },
  "results": {
    ...
    "summary": {
      "result": "failure",
      "short": "The summarization feature is currently only available in English. Please check out our API documentation for more details."
    }
  }
}
```
and 
```json
{
  "metadata": {
    ...
    "warnings": [
      {
        "parameter": "filler_words",
        "type": "unsupported_model",
        "message": "Filler Words is not available for the specified model. For supported models, see our docs: <link>"
      },
      {
        "parameter": "numerals",
        "type": "deprecated",
        "message": "The numerals parameter is deprecated. Please use smart_format=true instead. For more information, see our docs: <link>"
      }
    ]
  },
  "results": {
    ...
  }
}
```