### PR TITLE
chore: don't run workflow for pre-releases [skip ci]

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   release:
-    types: [ published ]
+    types: [released]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This, SHOULD, prevent the CD workflow from running for pre-releases of the SDK. This is so we can manually release them, and not accidentally update @latest with a prelease.