### PR TITLE
feat: export types and enums from main module

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,7 @@ jobs:
           npm clean-install
           npm run test:coverage
 
-      - name: Upload coverage results to Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage/lcov.info
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,4 +45,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./test/coverage/lcov.info
+          path-to-lcov: ./coverage/lcov.info

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,6 @@ import type { DeepgramClientOptions } from "./lib/types";
 export const createClient = (apiKey: string, options?: DeepgramClientOptions): DeepgramClient => {
   return new DeepgramClient(apiKey, options);
 };
+
+export * from "./lib/types";
+export * from "./lib/enums";


### PR DESCRIPTION
This PR adds types and enums to the exports of the main module. This allows a user to require types and enums along with the main `createClient` factory, to use them in client applications.

before:
```
const { createClient } = require("@deepgram/sdk");
const { LiveTranscriptionEvents } = require("@deepgram/sdk/dist/main/lib/enums");
// or
import { createClient } from "@deepgram/sdk";
import { LiveTranscriptionEvents } from "@deepgram/sdk/dist/main/lib/enums";
```

after:
```
const { createClient, LiveTranscriptionEvents } = require("@deepgram/sdk");
// or
import { createClient, LiveTranscriptionEvents } from "@deepgram/sdk";
```