### PR TITLE
fix(types): nested arrays in LiveTranscriptionEvent

### DIFF
--- a/src/lib/types/LiveTranscriptionEvent.ts
+++ b/src/lib/types/LiveTranscriptionEvent.ts
@@ -6,21 +6,17 @@ export interface LiveTranscriptionEvent {
   is_final?: boolean;
   speech_final?: boolean;
   channel: {
-    alternatives: [
-      {
-        transcript: string;
-        confidence: boolean;
-        words: [
-          {
-            word: string;
-            start: number;
-            end: number;
-            confidence: number;
-            punctuated_word: string;
-          }
-        ];
-      }
-    ];
+    alternatives: {
+      transcript: string;
+      confidence: boolean;
+      words: {
+        word: string;
+        start: number;
+        end: number;
+        confidence: number;
+        punctuated_word: string;
+      }[];
+    }[];
   };
   metadata: {
     request_id: string;


### PR DESCRIPTION
The `LiveTranscriptionEvent` type specifies that the `alternatives` and `words` nested fields are tuples of length 1, when they should be variable length arrays.

![image](https://github.com/deepgram/deepgram-node-sdk/assets/111262684/43a39eea-f62b-4d84-9a81-02f2eff42039)
