### PR TITLE
fix: allow the client to work in either websocket environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "cross-fetch": "^3.1.5",
         "deepmerge": "^4.3.1",
         "events": "^3.3.0",
-        "modern-isomorphic-ws": "^1.0.5"
+        "isomorphic-ws": "^5.0.0",
+        "ws": "^8.14.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
@@ -39,8 +40,7 @@
         "typedoc": "^0.22.16",
         "typescript": "^4.5.5",
         "webpack": "^5.69.1",
-        "webpack-cli": "^4.9.2",
-        "ws": "^8.13.0"
+        "webpack-cli": "^4.9.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3694,6 +3694,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -4520,14 +4528,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/modern-isomorphic-ws": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/modern-isomorphic-ws/-/modern-isomorphic-ws-1.0.5.tgz",
-      "integrity": "sha512-cgJzdkn1//XyYJsFZkjPYKN21CXeG+KC38Q5uFwTnbUwG3pmmsUDS9a5RRJ6lFnjsnEbUKx+rIXjxX/uCUFYvQ==",
-      "peerDependencies": {
-        "ws": "^8.11.0"
       }
     },
     "node_modules/mri": {
@@ -7332,9 +7332,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "cross-fetch": "^3.1.5",
     "deepmerge": "^4.3.1",
     "events": "^3.3.0",
-    "modern-isomorphic-ws": "^1.0.5"
+    "isomorphic-ws": "^5.0.0",
+    "ws": "^8.14.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.7",
@@ -81,8 +82,7 @@
     "typedoc": "^0.22.16",
     "typescript": "^4.5.5",
     "webpack": "^5.69.1",
-    "webpack-cli": "^4.9.2",
-    "ws": "^8.13.0"
+    "webpack-cli": "^4.9.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Such is the unique way that Node and JS differ on their WebSocket interfaces, this will attempt one and fall-back to the other if a syntax error is caught. Not great, but it works. I consider this a temporary solution to finding a library that handles WebSockets correctly in an isomorphic library.