### PR TITLE
feat: tightly couple the api key to the proxy logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ import { createClient } from "@deepgram/sdk";
 
 const deepgram = createClient(DEEPGRAM_API_KEY, {
   global: { url: "https://api.beta.deepgram.com" },
-  // proxy: { url: "http://localhost:8080" }
+  // restProxy: { url: "http://localhost:8080" }
 });
 ```
 
@@ -140,11 +140,15 @@ This SDK now works in the browser. If you'd like to make REST-based requests (pr
 import { createClient } from "@deepgram/sdk";
 
 const deepgram = createClient("proxy", {
-  proxy: { url: "http://localhost:8080" },
+  restProxy: { url: "http://localhost:8080" },
 });
 ```
 
+> Important: You must pass `"proxy"` as your API key, and use the proxy to set the `Authorization` header to your Deepgram API key.
+
 Your proxy service should replace the Authorization header with `Authorization: token <DEEPGRAM_API_KEY>` and return results verbatim to the SDK.
+
+Check out our example Node-based proxy here: [Deepgram Node Proxy](https://github.com/deepgram-devs/deepgram-node-proxy).
 
 # Transcription
 

--- a/src/packages/AbstractClient.ts
+++ b/src/packages/AbstractClient.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_OPTIONS, DEFAULT_URL } from "../lib/constants";
+import { DeepgramError } from "../lib/errors";
 import { applySettingDefaults, stripTrailingSlash } from "../lib/helpers";
 import { DeepgramClientOptions } from "../lib/types";
 
@@ -19,18 +20,24 @@ export abstract class AbstractClient {
     }
 
     if (!this.key) {
-      throw new Error("A deepgram API key is required");
+      throw new DeepgramError("A deepgram API key is required");
     }
 
     this.options = applySettingDefaults(options, DEFAULT_OPTIONS);
 
     if (!this.options.global?.url) {
-      throw new Error(
+      throw new DeepgramError(
         `An API URL is required. It should be set to ${DEFAULT_URL} by default. No idea what happened!`
       );
     }
 
     if (this.willProxy()) {
+      if (this.key !== "proxy") {
+        throw new DeepgramError(
+          `Do not attempt to pass any other API key than the string "proxy" when making proxied REST requests. Please ensure your proxy application is responsible for writing our API key to the Authorization header.`
+        );
+      }
+
       this.baseUrl = this.resolveBaseUrl(this.options.restProxy?.url as string);
 
       if (this.options.global.headers) {


### PR DESCRIPTION
- feat: tightly couple the api key to the proxy logic, so an api can't mistakenly be made public.
- chore: update proxy details in the readme file