### PR TITLE
fix: add missing type to channel interface

### DIFF
--- a/src/lib/types/SyncPrerecordedResponse.ts
+++ b/src/lib/types/SyncPrerecordedResponse.ts
@@ -18,6 +18,7 @@ interface Channel {
   search?: Search[];
   alternatives: Alternative[];
   detected_language?: string;
+  language_confidence?: number;
 }
 
 interface Entity {


### PR DESCRIPTION
This was missing from the channel definition.

PSA: It's possible this also affects other SDKs

fixes #212