### PR TITLE
fix: mistyped definition for alternative confidence on live event

### DIFF
--- a/src/lib/types/LiveTranscriptionEvent.ts
+++ b/src/lib/types/LiveTranscriptionEvent.ts
@@ -8,7 +8,7 @@ export interface LiveTranscriptionEvent {
   channel: {
     alternatives: {
       transcript: string;
-      confidence: boolean;
+      confidence: number;
       words: {
         word: string;
         start: number;


### PR DESCRIPTION
Incorrectly typed confidence on live event alternative definition.

Fixes 213